### PR TITLE
Use readline for REPL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=cc
 CFLAGS = -std=c89 -pedantic -Wall -Wextra -Wno-unused-parameter -fPIC -I. -I./src
-LDFLAGS = -lm -ldl
+LDFLAGS = -lm -ldl -lreadline
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)

--- a/src/shell.c
+++ b/src/shell.c
@@ -220,7 +220,7 @@ shell(struct lemon *lemon)
 		} else {
 			buffer = readline("... ");
 		}
-        add_history(buffer);
+		add_history(buffer);
 
 		if (!buffer) {
 			break;
@@ -256,7 +256,7 @@ shell(struct lemon *lemon)
 		       strlen(buffer));
 		codelen += strlen(buffer);
 
-        free(buffer);
+		free(buffer);
 
 		if (!check_stmt_is_closed(code, codelen)) {
 			continue;

--- a/src/shell.c
+++ b/src/shell.c
@@ -226,21 +226,21 @@ shell(struct lemon *lemon)
 			break;
 		}
 
-		if (strcmp(buffer, "\\help\n") == 0) {
+		if (strcmp(buffer, "\\help") == 0) {
 			printf("'\\dis'  print bytecode\n"
 			       "'\\list' print source code\n"
 			       "'\\exit' exit from shell\n");
 			continue;
 		}
-		if (strcmp(buffer, "\\dis\n") == 0) {
+		if (strcmp(buffer, "\\dis") == 0) {
 			machine_disassemble(lemon);
 			continue;
 		}
-		if (strcmp(buffer, "\\list\n") == 0) {
+		if (strcmp(buffer, "\\list") == 0) {
 			printf("%.*s", codelen, code);
 			continue;
 		}
-		if (strcmp(buffer, "\\exit\n") == 0) {
+		if (strcmp(buffer, "\\exit") == 0) {
 			break;
 		}
 

--- a/src/shell.c
+++ b/src/shell.c
@@ -10,7 +10,11 @@
 #include "generator.h"
 #include "ltable.h"
 
+#include <stdlib.h>
 #include <string.h>
+
+#include <readline/readline.h>
+#include <readline/history.h>
 
 int
 check_paren_is_closed(char *code, int len)
@@ -192,7 +196,7 @@ shell(struct lemon *lemon)
 	int codelen;
 	char stmt[4096];
 	char code[40960];
-	char buffer[4096];
+	char *buffer;
 
 	struct syntax *node;
 	struct lframe *frame;
@@ -212,12 +216,13 @@ shell(struct lemon *lemon)
 	memset(code, 0, sizeof(code));
 	while (1) {
 		if (check_stmt_is_closed(code, codelen)) {
-			fputs(">>> ", stdout);
+			buffer = readline(">>> ");
 		} else {
-			fputs("... ", stdout);
+			buffer = readline("... ");
 		}
+        add_history(buffer);
 
-		if (!fgets(buffer, sizeof(buffer), stdin)) {
+		if (!buffer) {
 			break;
 		}
 
@@ -242,14 +247,16 @@ shell(struct lemon *lemon)
 		/* copy buffer to stmt for error recovery */
 		memcpy(stmt + stmtlen,
 		       buffer,
-		       strnlen(buffer, sizeof(buffer)));
-		stmtlen += strnlen(buffer, sizeof(buffer));
+		       strlen(buffer));
+		stmtlen += strlen(buffer);
 
 		/* copy buffer to code */
 		memcpy(code + codelen,
 		       buffer,
-		       strnlen(buffer, sizeof(buffer)));
-		codelen += strnlen(buffer, sizeof(buffer));
+		       strlen(buffer));
+		codelen += strlen(buffer);
+
+        free(buffer);
 
 		if (!check_stmt_is_closed(code, codelen)) {
 			continue;


### PR DESCRIPTION
Use readline instead of fgets, to allow for line editing and history.
I can make it optional via a compile flag if you'd like.