### PR TITLE
fix a misleading comment in parser.c

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1474,7 +1474,7 @@ parser_break_stmt(struct lemon *lemon)
 }
 
 /*
- * continue_stmt : 'break' ';'
+ * continue_stmt : 'continue' ';'
  *               ;
  */
 static struct syntax *


### PR DESCRIPTION
Signed-off-by: shatuda <sd.lemon.lang@gmail.com>